### PR TITLE
Orthograpic camera

### DIFF
--- a/assets/shaders/quad.vert
+++ b/assets/shaders/quad.vert
@@ -16,6 +16,7 @@ layout (std430, binding = 0) buffer TransformSBO
 };
 
 uniform vec2 screenSize;
+uniform mat4 orthoProjection;
  
 // Output
 layout (location = 0) out vec2 textureCoordsOut;
@@ -52,9 +53,9 @@ void main()
     // Normalize Position
     {
       vec2 vertexPos = vertices[gl_VertexID];
-      vertexPos.y = -vertexPos.y + screenSize.y; // needs to be inverted due to OpenGL's coordinate system
-      vertexPos = 2.0 * (vertexPos / screenSize) - 1.0; // normalize to [-1, 1]
-      gl_Position = vec4(vertexPos, 0.0, 1.0);
+      // vertexPos.y = -vertexPos.y + screenSize.y; // needs to be inverted due to OpenGL's coordinate system
+      // vertexPos = 2.0 * (vertexPos / screenSize) - 1.0; // normalize to [-1, 1]
+      gl_Position = orthoProjection * vec4(vertexPos, 0.0, 1.0);
     }
 
     textureCoordsOut = textureCoords[gl_VertexID];

--- a/src/breaknotes_lib.h
+++ b/src/breaknotes_lib.h
@@ -310,6 +310,16 @@ struct Vec2
 {
   float x;
   float y;
+
+  Vec2 operator/(float scalar)
+  {
+    return {x / scalar, y / scalar};
+  }
+
+  Vec2 operator-(Vec2 other)
+  {
+    return {x - other.x, y - other.y};
+  }
 };
 
 struct IVec2
@@ -317,3 +327,85 @@ struct IVec2
   int x;
   int y;
 };
+
+Vec2 vec_2(IVec2 v)
+{
+  return Vec2{(float)v.x, (float)v.y};
+}
+
+struct Vec4
+{
+  union
+  {
+    float values[4];
+    struct
+    {
+      float x;
+      float y;
+      float z;
+      float w;
+    };
+
+    struct
+    {
+      float r;
+      float g;
+      float b;
+      float a;
+    };
+  };
+
+  float& operator[](int idx)
+  {
+    return values[idx];
+  }
+};
+
+struct Mat4
+{
+  union
+  {
+    Vec4 values[4];
+    struct 
+    {
+      float ax;
+      float bx;
+      float cx;
+      float dx;
+
+      float ay;
+      float by;
+      float cy;
+      float dy;
+
+      float az;
+      float bz;
+      float cz;
+      float dz;
+
+      float aw;
+      float bw;
+      float cw;
+      float dw;
+    };    
+  };
+
+  Vec4& operator[](int col)
+  {
+    return values[col];
+  }
+};
+
+Mat4 orthographic_projection(float left, float right, float top, float bottom)
+{
+  Mat4 result = {};
+  result.aw = -(right + left) / (right - left);
+  result.bw = (top + bottom) / (top - bottom);
+  result.cw = 0.0f; // near plane
+  result[0][0] = 2.0f / (right - left);
+  result[1][1] = 2.0f / (top - bottom);
+  result[2][2] = 1.0f; // far plane
+  result[3][3] = 1.0f;
+
+  return result;
+}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -31,8 +31,8 @@ EXPORT_FN void update_game(GameState* gameStateIn, RenderData* renderDataIn, Inp
     gameState->initialized = true;
   }
 
-  renderData->gameCamera.position.x = 160;
-  renderData->gameCamera.position.y = 90;
+  renderData->gameCamera.position.x = 0;
+  renderData->gameCamera.position.y = 0;
 
   draw_sprite(SPRITE_DICE, { 0.0f, 0.0f});
   

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,6 +5,9 @@
 // #############################################################################
 //                           Game Constants
 // #############################################################################
+constexpr int WORLD_WIDTH = 320;
+constexpr int WORLD_HEIGHT = 180;
+constexpr int TILESIZE = 8;
 
 // #############################################################################
 //                           Game Structs
@@ -13,19 +16,24 @@
 // #############################################################################
 //                           Game Functions
 // #############################################################################
-EXPORT_FN void update_game(RenderData* renderDataIn, Input* inputIn)
+EXPORT_FN void update_game(GameState* gameStateIn, RenderData* renderDataIn, Input* inputIn)
 {
   if(renderData != renderDataIn)
   {
+    gameState = gameStateIn;
     renderData = renderDataIn;
     input = inputIn;
   }
 
-  for(int x = 0; x < 10; x++)
+  if(!gameState ->initialized)
   {
-    for(int y = 0; y < 10; y++)
-    {
-      draw_sprite(SPRITE_DICE, { x * 100.0f, y * 100.0f}, {100.0f, 100.0f});
-    }
+    renderData->gameCamera.dimensions = {WORLD_WIDTH, WORLD_HEIGHT};
+    gameState->initialized = true;
   }
+
+  renderData->gameCamera.position.x = 160;
+  renderData->gameCamera.position.y = 90;
+
+  draw_sprite(SPRITE_DICE, { 0.0f, 0.0f});
+  
 }

--- a/src/game.h
+++ b/src/game.h
@@ -15,13 +15,19 @@ constexpr int tset = 5;
 // #############################################################################
 struct GameState
 {
+  bool initialized = false;
   IVec2 playerPos;
 };
+
+// #############################################################################
+//                           Game Globals
+// #############################################################################
+static GameState* gameState;
 
 // #############################################################################
 //                           Game Functions (Exposed)
 // #############################################################################
 extern "C"
 {
-  EXPORT_FN void update_game(RenderData* renderDataIn, Input* inputIn);
+  EXPORT_FN void update_game(GameState* gameStateIn, RenderData* renderDataIn, Input* inputIn);
 }

--- a/src/gl_renderer.cpp
+++ b/src/gl_renderer.cpp
@@ -20,6 +20,7 @@ struct GLContext
   GLuint textureID;
   GLuint transformSBOID;
   GLuint screenSizeID;
+  GLuint orthoProjectionID;
 };
 
 // #############################################################################
@@ -155,6 +156,7 @@ bool gl_init(BumpAllocator* transientStorage)
   // Uniforms
   {
     glContext.screenSizeID = glGetUniformLocation(glContext.programID, "screenSize");
+    glContext.orthoProjectionID = glGetUniformLocation(glContext.programID, "orthoProjection");
   }
   
   // sRGB output (even if input texture is non-sRGB -> don't rely on texture used)
@@ -184,6 +186,15 @@ void gl_render()
   // Copy screen size to the GPU
   Vec2 screenSize = {(float)input->screenSizeX, (float)input->screenSizeY};
   glUniform2fv(glContext.screenSizeID, 1, &screenSize.x);
+
+  // Orthographic Projection
+  OrthographicCamera2D camera = renderData->gameCamera;
+
+  Mat4 orthoProjection = orthographic_projection(camera.position.x - camera.dimensions.x / 2.0f, 
+                                                 camera.position.x + camera.dimensions.x / 2.0f, 
+                                                 camera.position.y - camera.dimensions.y / 2.0f, 
+                                                 camera.position.y + camera.dimensions.y / 2.0f);
+  glUniformMatrix4fv(glContext.orthoProjectionID, 1, GL_FALSE, &orthoProjection.ax);
 
   // Opaque Objects
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,14 @@ int main()
         return -1;
     }
 
+    gameState = (GameState*)bump_alloc(&persistentStorage, sizeof(GameState));
+
+    if(!gameState)
+    {
+        SM_ERROR("Failed to allocate GameState");
+        return -1;
+    }
+
     renderData = (RenderData*)bump_alloc(&persistentStorage, sizeof(RenderData));
     if(!renderData)
     {
@@ -67,7 +75,7 @@ int main()
         reload_game_dll(&transientStorage);
         // Update
         platform_update_window();
-        update_game(renderData, input);
+        update_game(gameState, renderData, input);
         gl_render();
         platform_swap_buffers();
 
@@ -77,9 +85,9 @@ int main()
     return 0;
 }
 
-void update_game(RenderData* renderDataIn, Input* inputIn)
+void update_game(GameState* gameStateIn, RenderData* renderDataIn, Input* inputIn)
 {
-    update_game_ptr(renderDataIn, inputIn);
+    update_game_ptr(gameStateIn, renderDataIn, inputIn);
 }
 
 void reload_game_dll(BumpAllocator* transientStorage)

--- a/src/render_interface.h
+++ b/src/render_interface.h
@@ -11,6 +11,14 @@ constexpr int MAX_TRANSFORMS = 1000; // Maximum number of transforms allowed
 // #############################################################################
 //                           Renderer Structs
 // #############################################################################
+struct OrthographicCamera2D
+{
+  float zoom = 1.0f;
+  Vec2 dimensions;
+  Vec2 position;
+};
+
+
 struct Transform 
 {
   Vec2 pos;          // Position of the sprite
@@ -21,6 +29,8 @@ struct Transform
 
 struct RenderData
 {
+  OrthographicCamera2D gameCamera;      // Camera used to render the game
+  OrthographicCamera2D uiCamera;        // Camera used to render the UI
   int transformCount;                    // Number of transforms currently in use
   Transform transforms[MAX_TRANSFORMS];  // Array of transforms
 };
@@ -35,13 +45,13 @@ static RenderData* renderData; // Global render data instance
 // #############################################################################
 
 
-void draw_sprite(SpriteID spriteID, Vec2 pos, Vec2 size)
+void draw_sprite(SpriteID spriteID, Vec2 pos)
 {
   Sprite sprite = get_sprite(spriteID);
 
   Transform transform = {};
-  transform.pos = pos;
-  transform.size = size;
+  transform.pos = pos - vec_2(sprite.spriteSize) / 2.0f;
+  transform.size = vec_2(sprite.spriteSize);
   transform.atlasOffset = sprite.atlasOffset;
   transform.spriteSize = sprite.spriteSize;
 


### PR DESCRIPTION
Added the option to move the camera, instead of having to move the object to make them appear on screen.

Matrix has been created that handles the orthographic_projection. That matrix is being used to create a gameCamera in renderData.